### PR TITLE
Set up DB using env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+.env
 .venv
 .vscode
 !.gitignore

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Stop the services (when done testing):
 docker-compose down
 ```
 
+### 2.2 Environment Variables
+
+Copy the `.env` file from Google Drive to the root of the project directory. This file contains the environment variables needed to run the backend and persistence layers.
+
 ## 3 License
 
 This project is licensed under the MIT License. See the LICENSE file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,19 +9,20 @@ services:
       # - ./certs:/app/certs # SSL certificates
     environment:
       MYSQL_HOST: db
-      MYSQL_DATABASE: placeholderdb
-      MYSQL_USER: placeholderuser
-      MYSQL_PASSWORD: placeholderpassword
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     networks:
       - internal
 
   db:
     image: mysql:latest
     environment:
-      MYSQL_ROOT_PASSWORD: placeholderrootpassword
-      MYSQL_DATABASE: placeholderdb
-      MYSQL_USER: placeholderuser
-      MYSQL_PASSWORD: placeholderpassword
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+
     volumes:
       - ./db/seed.sql:/docker-entrypoint-initdb.d/seed.sql # Seed data
       # - ./certs:/etc/mysql/certs # SSL certificates for MySQL


### PR DESCRIPTION
This modifies `docker-compose` to securely set up the database based on an environment file at the root of the project